### PR TITLE
status driver

### DIFF
--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -1,0 +1,22 @@
+/*******************
+ * This is the pubsub driver that should tell caspa about the melted status
+ *
+ *******************/
+
+exports = module.exports = function(){
+    var defaults = { // copied from caspa/models.App.Status
+        _id: 0,
+        piece: {
+            previous: null,
+            curent: null,
+            next: null
+        },
+        show: {
+            previous: null,
+            current: null,
+            next: null,
+        },
+        source: null,
+        no_air: false
+    };
+};

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -36,6 +36,9 @@ function CaspaDriver() {
     CaspaDriver.prototype.publish = function(status) {
         this.publisher.publish({backend: this.channel, model: status});
     };
+    CaspaDriver.prototype.publishStatus = function(status) {
+        this.publisher.publish({backend: "mostoStatus", model: status})
+    };
 }
 
 exports = module.exports = function() {

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -133,6 +133,10 @@ function CaspaDriver() {
                                 model: message});
         return message;
     };
+    CaspaDriver.prototype.dropMessage = function(message) {
+        this.publisher.publish({backend: "mostoMessage", method: 'delete',
+                                model: message});
+    };
 }
 
 util.inherits(CaspaDriver, events.EventEmitter);

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -36,11 +36,13 @@ function CaspaDriver() {
     events.EventEmitter.call(this);
     var self = this;
     this.status = _.clone(defaults);
+    this.db = mbc.db();
     this.publisher = mbc.pubsub();
 
     CaspaDriver.prototype.setupAll = function() {
         var setups = [
-            this.setupStatus
+            this.setupStatus,
+            this.setupMessages,
         ];
         var sendReady = _.after(setups.length, function() {
             self.emit('ready');
@@ -51,8 +53,7 @@ function CaspaDriver() {
     };
 
     CaspaDriver.prototype.setupStatus = function(callback) {
-        var db = mbc.db();
-        var col = db.collection('status');
+        var col = this.db.collection('status');
         col.findOne({_id: 2}, function(err, res) {
             if( err )
                 // err.. do something?
@@ -67,6 +68,11 @@ function CaspaDriver() {
                 callback();
             }
         });
+    };
+
+    CaspaDriver.prototype.setupMessages = function(callback) {
+        // I think we should assume at init there's no sticky errors?
+        this.db.collection('mostomessages').remove(callback);
     };
 
     CaspaDriver.prototype.setStatus = function(meltedStatus) {

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -27,7 +27,6 @@ function CaspaDriver() {
     events.EventEmitter.call(this);
     var self = this;
     this.status = _.clone(defaults);
-    this.channel = "mostoStatus";
     this.publisher = mbc.pubsub();
 
     var setups = [
@@ -63,10 +62,7 @@ function CaspaDriver() {
     CaspaDriver.prototype.setStatus = function(status) {
         // this overrides this.status with the values passed by status
         this.status = _.extend(this.status, status);
-        this.publish(status);
-    };
-    CaspaDriver.prototype.publish = function(status) {
-        this.publisher.publish({backend: this.channel, model: status});
+        this.publishStatus(status);
     };
     CaspaDriver.prototype.publishStatus = function(status) {
         this.publisher.publish({backend: "mostoStatus", model: status})

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -7,7 +7,7 @@ _ = require('underscore');
 mbc = require('mbc-common');
 
 defaults = { // copied from caspa/models.App.Status
-    _id: 0,
+    _id: 1,
     piece: {
         previous: null,
         curent: null,

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -37,3 +37,8 @@ function CaspaDriver() {
         this.publisher.publish(this.channel, status);
     };
 }
+
+exports = module.exports = function() {
+    driver = new CaspaDriver();
+    return driver;
+};

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -34,7 +34,7 @@ function CaspaDriver() {
         this.publish(status);
     };
     CaspaDriver.prototype.publish = function(status) {
-        this.publisher.publish(this.channel, status);
+        this.publisher.publish({backend: this.channel, model: status});
     };
 }
 

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -25,7 +25,7 @@ defaults = { // copied from caspa/models.App.Status
 function CaspaDriver() {
     var self = this;
     this.status = _.clone(defaults);
-    this.channel = "mosto";
+    this.channel = "mostoStatus";
     this.publisher = mbc.pubsub();
     
     CaspaDriver.prototype.setStatus = function(status) {

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -2,10 +2,10 @@
  * This is the pubsub driver that should tell caspa about the melted status
  *
  *******************/
-events = require('events');
-utils = require('utils');
-_ = require('underscore');
-mbc = require('mbc-common');
+var events = require('events');
+var util = require('util');
+var _ = require('underscore');
+var mbc = require('mbc-common');
 
 defaults = { // copied from caspa/models.App.Status
     _id: 1,

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -2,7 +2,8 @@
  * This is the pubsub driver that should tell caspa about the melted status
  *
  *******************/
-
+events = require('events');
+utils = require('utils');
 _ = require('underscore');
 mbc = require('mbc-common');
 
@@ -23,6 +24,7 @@ defaults = { // copied from caspa/models.App.Status
 };
 
 function CaspaDriver() {
+    events.EventEmitter.call(this);
     var self = this;
     this.status = _.clone(defaults);
     this.channel = "mostoStatus";
@@ -40,6 +42,8 @@ function CaspaDriver() {
         this.publisher.publish({backend: "mostoStatus", model: status})
     };
 }
+
+util.inherits(CaspaDriver, events.EventEmitter);
 
 exports = module.exports = function() {
     driver = new CaspaDriver();

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -29,7 +29,17 @@ function CaspaDriver() {
     this.status = _.clone(defaults);
     this.channel = "mostoStatus";
     this.publisher = mbc.pubsub();
-    
+
+    var setups = [
+    ];
+    var sendReady = _.times(setups.length, function() {
+        self.emit('ready');
+    });
+
+    setups.forEach(function(setup){
+        setup(sendReady);
+    });
+
     CaspaDriver.prototype.setStatus = function(status) {
         // this overrides this.status with the values passed by status
         this.status = _.extend(this.status, status);

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -10,17 +10,17 @@ var mbc = require('mbc-common');
 defaults = { // copied from caspa/models.App.Status
     _id: 2,
     piece: {
-        previous: null,
-        curent: null,
-        next: null
+        previous: {name: ''},
+        current:  {name: '', progress: '0%'},
+        next:     {name: ''},
     },
     show: {
-        previous: null,
-        current: null,
-        next: null,
+        previous: {_id: -1},
+        current:  {_id: -1},
+        next:     {_id: -1},
     },
     source: null,
-    no_air: false
+    on_air: false,
 };
 
 function CaspaDriver() {

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -25,8 +25,8 @@ defaults = { // copied from caspa/models.App.Status
 function CaspaDriver() {
     var self = this;
     this.status = _.clone(defaults);
-    this.channel = "mosto"
-    this.publisher = mbc.JSONredis.createJSONClient();
+    this.channel = "mosto";
+    this.publisher = mbc.pubsub();
     
     CaspaDriver.prototype.setStatus = function(status) {
         // this overrides this.status with the values passed by status

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -29,16 +29,17 @@ function CaspaDriver() {
     this.status = _.clone(defaults);
     this.publisher = mbc.pubsub();
 
-    var setups = [
-       self.setupStatus
-    ];
-    var sendReady = _.times(setups.length, function() {
-        self.emit('ready');
-    });
-
-    setups.forEach(function(setup){
-        setup(sendReady);
-    });
+    CaspaDriver.prototype.setupAll = function() {
+        var setups = [
+            this.setupStatus
+        ];
+        var sendReady = _.after(setups.length, function() {
+            self.emit('ready');
+        });
+        setups.forEach(function(setup){
+            setup(sendReady);
+        });
+    };
 
     CaspaDriver.prototype.setupStatus = function(callback) {
         var db = mbc.db();
@@ -73,5 +74,7 @@ util.inherits(CaspaDriver, events.EventEmitter);
 
 exports = module.exports = function() {
     driver = new CaspaDriver();
+    driver.setupAll();
+
     return driver;
 };

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -95,7 +95,7 @@ function CaspaDriver() {
             },
             on_air: true,
         };
-        status.piece.current.progress = meltedStatus.position + "%";
+        status.piece.current.progress = meltedStatus.position * 100 + "%";
 
         for( var i in meltedStatus.clips ) {
             if( i < meltedStatus.current ) {

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -8,7 +8,7 @@ var _ = require('underscore');
 var mbc = require('mbc-common');
 
 defaults = { // copied from caspa/models.App.Status
-    _id: 1,
+    _id: 2,
     piece: {
         previous: null,
         curent: null,
@@ -44,7 +44,7 @@ function CaspaDriver() {
     CaspaDriver.prototype.setupStatus = function(callback) {
         var db = mbc.db();
         var col = db.collection('status');
-        col.findOne({_id: 1}, function(err, res) {
+        col.findOne({_id: 2}, function(err, res) {
             if( err )
                 // err.. do something?
                 return;

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -3,20 +3,37 @@
  *
  *******************/
 
-exports = module.exports = function(){
-    var defaults = { // copied from caspa/models.App.Status
-        _id: 0,
-        piece: {
-            previous: null,
-            curent: null,
-            next: null
-        },
-        show: {
-            previous: null,
-            current: null,
-            next: null,
-        },
-        source: null,
-        no_air: false
-    };
+_ = require('underscore');
+mbc = require('mbc-common');
+
+defaults = { // copied from caspa/models.App.Status
+    _id: 0,
+    piece: {
+        previous: null,
+        curent: null,
+        next: null
+    },
+    show: {
+        previous: null,
+        current: null,
+        next: null,
+    },
+    source: null,
+    no_air: false
 };
+
+function CaspaDriver() {
+    var self = this;
+    this.status = _.clone(defaults);
+    this.channel = "mosto"
+    this.publisher = mbc.JSONredis.createJSONClient();
+    
+    CaspaDriver.prototype.setStatus = function(status) {
+        // this overrides this.status with the values passed by status
+        this.status = _.extend(this.status, status);
+        this.publish(status);
+    };
+    CaspaDriver.prototype.publish = function(status) {
+        this.publisher.publish(this.channel, status);
+    };
+}

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -50,7 +50,7 @@ function CaspaDriver() {
                 return;
             if( !res ) {
                 // the status doesn't exist, create it
-                col.create(self.status, function(err, itm) {
+                col.save(self.status, function(err, itm) {
                     callback();
                 });
             } else {

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -31,6 +31,7 @@ function CaspaDriver() {
     this.publisher = mbc.pubsub();
 
     var setups = [
+       self.setupStatus
     ];
     var sendReady = _.times(setups.length, function() {
         self.emit('ready');
@@ -39,6 +40,25 @@ function CaspaDriver() {
     setups.forEach(function(setup){
         setup(sendReady);
     });
+
+    CaspaDriver.prototype.setupStatus = function(callback) {
+        var db = mbc.db();
+        var col = db.collection('status');
+        col.findOne({_id: 1}, function(err, res) {
+            if( err )
+                // err.. do something?
+                return;
+            if( !res ) {
+                // the status doesn't exist, create it
+                col.create(self.status, function(err, itm) {
+                    callback();
+                });
+            } else {
+                // res existed, just signal as ready
+                callback();
+            }
+        });
+    };
 
     CaspaDriver.prototype.setStatus = function(status) {
         // this overrides this.status with the values passed by status

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -91,26 +91,13 @@ function CaspaDriver() {
                 next:     makePiece(clips[meltedStatus.next]),
             },
             show: {
-                current: { _id: clips[meltedStatus.current].playlist_id },
+                previous: { _id: meltedStatus.show.previous.id },
+                current: { _id: meltedStatus.show.current.id },
+                next: { _id: meltedStatus.show.next.id },
             },
             on_air: true,
         };
         status.piece.current.progress = meltedStatus.position * 100 + "%";
-
-        for( var i in meltedStatus.clips ) {
-            if( i < meltedStatus.current ) {
-                if( clips[i].playlist_id != status.show.current ) {
-                    status.show.previous = { _id: clips[i].playlist_id };
-                }
-            } else if ( i > meltedStatus.current ) {
-                if( clips[i].playlist_id != status.show.current ) {
-                    // I'm pass `previous` and the first into `next`, so I'm
-                    // done here
-                    status.show.next = { _id: clips[i].playlist_id };
-                    break;
-                }
-            }
-        }
 
         this.status = _.extend(this.status, status);
         // except next. If that's undefined, I just don't know!

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -26,6 +26,12 @@ defaults = { // copied from caspa/models.App.Status
     on_air: false,
 };
 
+function MostoMessage(value, description, message) {
+    this.value = value;
+    this.description = description;
+    this.message = message;
+}
+
 function CaspaDriver() {
     events.EventEmitter.call(this);
     var self = this;

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -120,6 +120,19 @@ function CaspaDriver() {
     CaspaDriver.prototype.publishStatus = function(status) {
         this.publisher.publish({backend: "mostoStatus", model: status})
     };
+
+    CaspaDriver.prototype.publishMessage = function(code, description, message, sticky) {
+        message = new MostoMessage(code, description, message);
+        var method = 'emit';
+        if( sticky ) {
+            // I create an id with the timestamp to be able to cancel the error afterwards
+            message.stickId = (new moment()).valueOf();
+            method = 'create';
+        }
+        this.publisher.publish({backend: "mostoMessage", method: method,
+                                model: message});
+        return message;
+    };
 }
 
 util.inherits(CaspaDriver, events.EventEmitter);

--- a/drivers/status/pubsub.js
+++ b/drivers/status/pubsub.js
@@ -1,7 +1,10 @@
-/*******************
+/***************************************************************************
  * This is the pubsub driver that should tell caspa about the melted status
  *
- *******************/
+ * this code is more than slightly coupled with caspa's section that deals
+ * with the messages. It should probably be refactored a little, things like
+ * creating constants in and handling db collections in mbc-common
+ ***************************************************************************/
 var events = require('events');
 var util = require('util');
 var _ = require('underscore');


### PR DESCRIPTION
see https://github.com/inaes-tic/mbc-mosto/pull/54 for some comments

This code is coupled with caspa's handling code (it says so in the comments) and some of it should be moved to mbc-common and implemented as backbone models.

Nonetheless, it works and is not _extremely_ ugly. I'll work on migrating to mbc-common on a new branch based on this tip

here's a description of the status messages this expects. 

```
    /*
      meltedStatus = {
          clip: {
              previous = position in list
              current = position in list
              next = position in list
          },
          show: {
              previous = Playlist
              current = Playlist
              next = Playlist
          }
          position = playback % of current
          clips = [clip list]
      };
    */
```
