### PR TITLE
removed avconv: using melt for video encoding and generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ services:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get build-dep -qq melt
-  - sudo apt-get install -qq ffmpeg melt libmlt-dev libmlt++-dev
+  - sudo apt-get install -qq ffmpeg melt libmlt-dev libmlt++-dev x264

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ MELTED_BUILD=${ROOT}/melted/BUILD
 MELTED_INTREE=${MELTED_BUILD}/bin/melted
 MELTED = $(shell sh -c "which melted || echo ${MELTED_INTREE}")
 NC=$(shell which nc netcat telnet | head -1)
-AVCONV=$(shell which avconv | head -1)
 TEST_VIDEOS=test/videos/SMPTE_Color_Bars_01.mp4 test/videos/SMPTE_Color_Bars_02.mp4 test/videos/SMPTE_Color_Bars_03.mp4
 
 export NODE_CONFIG_DIR ?= $(PWD)/node_modules/mbc-common/config
@@ -51,9 +50,9 @@ melted-restart: ${MELTED} melted-kill melted-run
 
 melted-check: ${MELTED}
 
-images: test/images/SMPTE_Color_Bars_01.png test/images/SMPTE_Color_Bars_02.png test/images/SMPTE_Color_Bars_03.png 
+images: test/images/SMPTE_Color_Bars_01.png test/images/SMPTE_Color_Bars_02.png test/images/SMPTE_Color_Bars_03.png
 
-%.png: test/images/SMPTE_Color_Bars.png 
+%.png: test/images/SMPTE_Color_Bars.png
 	cp $< $@
 
 videos: test/videos/SMPTE_Color_Bars_01.mp4 test/videos/SMPTE_Color_Bars_02.mp4 test/videos/SMPTE_Color_Bars_03.mp4
@@ -63,7 +62,7 @@ test/videos/%.avi: test/images/%.png
 	avconv -loop 1 -f image2 -i $< -t 30 $@ &> /dev/null
 
 test/videos/%.mp4: test/images/%.png
-	${AVCONV} -loop 1 -f image2 -i $< -t 30 $@ &> /dev/null
+	melt $< in=0 out=750 -consumer avformat:$@ vcodec=libx264 acodec=none
 
 test: videos ${MOCHA} melted-check
 	${NODE} ${MOCHA}

--- a/api/Melted.js
+++ b/api/Melted.js
@@ -1,17 +1,9 @@
 var spawn = require('child_process').spawn;
 var net = require('net');
 var semaphore = require('semaphore')(1);
-
-var conf = {
-    bin: process.env.MELTED || "melted",
-    root: process.env.MELTED_ROOT || process.env.PWD,
-    host: process.env.MELTED_HOST || "localhost",
-    port: process.env.MELTED_PORT || 5250,
-    output: process.env.MELTED_OUTPUT || "sdl"
-};
-
-var melted_bin_path = process.env.PWD+ '/melted/BUILD/bin/melted';
-var melted_lib_path = process.env.PWD+ '/melted/BUILD/lib';
+var conf = require('mbc-common').config.Mosto.Melted;
+var melted_bin_path = conf.root + '/melted/BUILD/bin/melted';
+var melted_lib_path = conf.root + '/melted/BUILD/lib';
 
 _meltedbin = function(callback,errorCallback) {
     console.log("Melted.js: executing _meltedbin()");

--- a/drivers/mvcp/mvcp-driver.js
+++ b/drivers/mvcp/mvcp-driver.js
@@ -1,5 +1,5 @@
 var melted_node_driver = require("./melted-node-driver"),
-    conf               = require('mbc-common').config.Mosto.Mvcp;
+    conf               = require('mbc-common').config.Mosto.Melted;
 
 exports = module.exports = function(type) {
     console.log("mbc-mosto: [INFO] Creating server for type [" + type + "]");

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "watchr"      : "2.4.x",
         "moment"      : "2.0.0",
         "mubsub"      : "git://github.com/inaes-tic/mubsub.git",
-        "mbc-common"  : "git://github.com/inaes-tic/mbc-common.git#0.0.1",
+        "mbc-common"  : "git://github.com/inaes-tic/mbc-common.git",
         "node-mlt"    : "git://github.com/inaes-tic/node-mlt.git#0.0.1",
         "semaphore"   : "1.0.x"
     },


### PR DESCRIPTION
NOTES:
originally $(AVCONV) was "avconv" or "ffmpeg", but the argument -loop
was unknown to ffmpeg, and avconv was not in the project requirements
(to get avconv you have to install libav-tools).
