### PR TITLE
Jmrunge/sync timeout

### DIFF
--- a/drivers/playlists/mongo-driver.js
+++ b/drivers/playlists/mongo-driver.js
@@ -118,7 +118,7 @@ mongo_driver.prototype.getPlaylists = function(window, callback) {
                     logger.error("Error processing playlists: ", err);
                     return self.emit('md-error', err);
                 } else {
-                    logger.debug("Playlists obtained: ", playlists);
+                    logger.debug("%d Playlists obtained", playlists.length);
                 }
                 if( callback )
                     callback(playlists);
@@ -178,7 +178,7 @@ mongo_driver.prototype.createPlaylist = function(sched, callback) {
 
             var playlist = new models.Playlist({"id": playlist_id, "name": name, "start": startDate, "end": endDate, "mode": "snap", "medias": medias});
 
-            logger.debug("Created Playlist:", playlist);
+            logger.debug("Created Playlist. name: %s, id: %s, length: %d", playlist.get('name'), playlist.get('id'), playlist.get('medias').length);
 
             callback(err, playlist);
         });

--- a/heartbeats.js
+++ b/heartbeats.js
@@ -87,7 +87,9 @@ heartbeats.prototype.scheduleGc = function() {
 
 heartbeats.prototype.scheduleSync = function() {
     var self = this;
+    logger.info("scheduleSync called for %d milliseconds", self.config.sync_interval);
     setTimeout(function() {
+        logger.info("scheduleSync timeout fired");
         self.melted_medias.take(self.syncMelted.bind(self));
     }, self.config.sync_interval);
 };

--- a/heartbeats.js
+++ b/heartbeats.js
@@ -250,6 +250,7 @@ heartbeats.prototype.syncMelted = function() {
 };
 
 heartbeats.prototype.sendSyncEnded = function(result, error) {
+    logger.debug("sending sync ended");
     this.emit("syncEnded", result, error);
 };
 

--- a/heartbeats.js
+++ b/heartbeats.js
@@ -191,7 +191,7 @@ heartbeats.prototype.syncMelted = function() {
             var meltedClip = meltedStatus.currentClip;
             if (!meltedClip) {
                 logger.info("[syncMelted] There's no clip playing");
-                result = result.then(self.fixMelted(expected));
+                result = result.then(self.fixMelted.bind(self, expected));
             } else if (expected.media.get("id").toString() !== meltedClip.id.toString()) {
                 logger.info("[syncMelted] Expected and playing medias aren't the same");
                 var index = expected.media.get('actual_order');
@@ -218,22 +218,22 @@ heartbeats.prototype.syncMelted = function() {
                 logger.debug("frames phase: %d", frames);
                 if (frames > expected.media.get('fps')) {
                     logger.info("[syncMelted] I'm over 1 second off");
-                    result = result.then(self.fixMelted(expected));
+                    result = result.then(self.fixMelted.bind(self, expected));
                 }
             } else {
                 logger.info("[syncMelted Expected and playing medias are the same");
                 if (Math.abs(meltedClip.currentFrame - expected.frame) > expected.media.get('fps')) {
                     logger.info("[syncMelted] I'm over 1 second off")
-                    result = result.then(self.fixMelted(expected));
+                    result = result.then(self.fixMelted.bind(self, expected));
                 }
             }
             if (meltedStatus.status !== "playing") {
                 logger.info("[syncMelted] need to start playing");
-                result = result.then(self.startPlaying()).then(self.sendStatus());
+                result = result.then(self.startPlaying.bind(self)).then(self.sendStatus.bind(self));
             } else {
-                result = result.then(self.sendStatus());
+                result = result.then(self.sendStatus.bind(self));
             }
-            result = result.then(self.sendSyncEnded("Success"));
+            result = result.then(self.sendSyncEnded.bind(self, "Success"));
             return result;
         } else {
             self.handleNoMedias();

--- a/test/heartbeats-test.js
+++ b/test/heartbeats-test.js
@@ -49,6 +49,8 @@ describe('Mosto Heartbeats Test', function() {
             self.outOfSync = 0;
             self.hbErrors = 0;
             self.noClips = 0;
+            self.start = 0;
+            self.end = 0;
             before(function(done) {
                 self.hb.on('forceCheckout', function() {
                     self.ckeckouts++;
@@ -67,6 +69,14 @@ describe('Mosto Heartbeats Test', function() {
                 });
                 self.hb.on('noClips', function() {
                     self.noClips++;
+                });
+                self.hb.on('syncStarted', function() {
+                    if (self.start === 0 && self.end > 0)
+                        self.start = moment();
+                });
+                self.hb.on('syncEnded', function() {
+                    if (self.end === 0)
+                        self.end = moment();
                 });
                 self.hb.init();
                 setTimeout(function() {
@@ -98,6 +108,17 @@ describe('Mosto Heartbeats Test', function() {
             it('-- Should have received > 1 noClips events', function() {
                 console.warn("Received " + self.noClips + " events");
                 assert.ok(self.noClips > 1);
+            });
+            it('-- Should have received syncStarted event', function() {
+                assert.ok(self.start > 0);
+            });
+            it('-- Should have received syncEnded event', function() {
+                assert.ok(self.end > 0);
+            });
+            it('-- Should wait 50 ms between end and start of sync', function() {
+                var millis = self.start - self.end;
+                console.warn("Ms " + millis);
+                assert.ok(millis >= 50);
             });
         });
 
@@ -137,6 +158,8 @@ describe('Mosto Heartbeats Test', function() {
         self.outOfSync = 0;
         self.hbErrors = 0;
         self.noClips = 0;
+        self.start = 0;
+        self.end = 0;
 
         before(function(done) {
             var config = {
@@ -165,6 +188,14 @@ describe('Mosto Heartbeats Test', function() {
             });
             self.hb.on('noClips', function() {
                 self.noClips++;
+            });
+            self.hb.on('syncStarted', function() {
+                if (self.start === 0 && self.end > 0)
+                    self.start = moment();
+            });
+            self.hb.on('syncEnded', function() {
+                if (self.end === 0)
+                    self.end = moment();
             });
             self.hb.init();
 
@@ -216,6 +247,17 @@ describe('Mosto Heartbeats Test', function() {
                     console.warn("Received " + self.noClips + " events");
                 assert.equal(self.noClips, 0);
                 done();
+            });
+            it('-- Should have received syncStarted event', function() {
+                assert.ok(self.start > 0);
+            });
+            it('-- Should have received syncEnded event', function() {
+                assert.ok(self.end > 0);
+            });
+            it('-- Should wait 50 ms between end and start of sync', function() {
+                var millis = self.start - self.end;
+                console.warn("Ms " + millis);
+                assert.ok(millis >= 50);
             });
         });
         describe('-- Make a goto in melted and wait 1.5 second', function() {

--- a/test/heartbeats-test.js
+++ b/test/heartbeats-test.js
@@ -273,13 +273,20 @@ describe('Mosto Heartbeats Test', function() {
         });
         describe('-- Make a goto in melted and wait 1.5 second', function() {
             before(function(done) {
+                // I assume current and expected are the same
+                var current = Mosto.Playlists().get('melted_medias').getExpectedMedia();
+                var frame = current.frame + 500;
+                if(frame > current.media.get('out'))
+                    frame = "500 " + current.get('actual_order');
+                else
+                    frame = '' + frame;
                 self.checkouts = 0;
                 self.clipStatus = 0;
                 self.startPlaying = 0;
                 self.outOfSync = 0;
                 self.hbErrors = 0;
                 self.noClips = 0;
-                exec("echo 'goto u0 500' | nc localhost 5250", function (error, stdout, stderr) {
+                exec("echo 'goto u0 " + frame + "' | nc localhost 5250", function (error, stdout, stderr) {
                     setTimeout(function() {
                         done();
                     }, 1500);

--- a/test/heartbeats-test.js
+++ b/test/heartbeats-test.js
@@ -49,8 +49,8 @@ describe('Mosto Heartbeats Test', function() {
             self.outOfSync = 0;
             self.hbErrors = 0;
             self.noClips = 0;
-            self.start = 0;
-            self.end = 0;
+            self.start = [];
+            self.end = [];
             before(function(done) {
                 self.hb.on('forceCheckout', function() {
                     self.ckeckouts++;
@@ -71,12 +71,10 @@ describe('Mosto Heartbeats Test', function() {
                     self.noClips++;
                 });
                 self.hb.on('syncStarted', function() {
-                    if (self.start === 0 && self.end > 0)
-                        self.start = moment();
+                    self.start.push(moment());
                 });
                 self.hb.on('syncEnded', function() {
-                    if (self.end === 0)
-                        self.end = moment();
+                    self.end.push(moment());
                 });
                 self.hb.init();
                 setTimeout(function() {
@@ -110,15 +108,28 @@ describe('Mosto Heartbeats Test', function() {
                 assert.ok(self.noClips > 1);
             });
             it('-- Should have received syncStarted event', function() {
-                assert.ok(self.start > 0);
+                //assert.ok(self.start > 0);
+                console.log('Got', self.start.length);
+                assert.ok(self.start.length > 0);
             });
             it('-- Should have received syncEnded event', function() {
-                assert.ok(self.end > 0);
+                //assert.ok(self.end > 0);
+                console.log('Got', self.end.length);
+                assert.ok(self.end.length > 0);
+            });
+            it('-- Should have received more starts than ends', function() {
+                assert.ok(self.start.length >= self.end.length);
             });
             it('-- Should wait 50 ms between end and start of sync', function() {
-                var millis = self.start - self.end;
-                console.warn("Ms " + millis);
-                assert.ok(millis >= 50);
+                var results = [];
+                var messages = [];
+                for(var i = 1 ; i < self.start.length ; i++) {
+                    var millis = self.start[i] - self.end[i-1];
+                    results.push(millis >= 50);
+                    messages.push(i + ": Ms " + millis);
+                }
+                console.warn(messages.join("|"));
+                assert.ok(_.all(results));
             });
         });
 

--- a/test/heartbeats-test.js
+++ b/test/heartbeats-test.js
@@ -125,7 +125,7 @@ describe('Mosto Heartbeats Test', function() {
                 var messages = [];
                 for(var i = 1 ; i < self.start.length ; i++) {
                     var millis = self.start[i] - self.end[i-1];
-                    results.push(millis >= 50);
+                    results.push(millis >= 48);
                     messages.push(i + ": Ms " + millis);
                 }
                 console.warn(messages.join("|"));
@@ -268,7 +268,7 @@ describe('Mosto Heartbeats Test', function() {
             it('-- Should wait 50 ms between end and start of sync', function() {
                 var millis = self.start - self.end;
                 console.warn("Ms " + millis);
-                assert.ok(millis >= 50);
+                assert.ok(millis >= 48);
             });
         });
         describe('-- Make a goto in melted and wait 1.5 second', function() {


### PR DESCRIPTION
This seems to fix most of the intermitent travis testing issues. There is only ONE real set of bugs fixed here which is that the calls inside then`then()` in heartbeats' promises were immediate, passing `then` the function's result, not the functions as callbacks
