### PR TITLE
Misc fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,14 @@ MELT_TIME_FILTER=-filter dynamictext:"\#frame\#/\#out\#" halign=centre valign=mi
                          geometry=0%/43:100%x100%:100 pad=1
 
 export NODE_CONFIG_DIR ?= $(PWD)/node_modules/mbc-common/config
+LOG_LEVEL ?= info
 
 .PHONY: test
 
 all: test serve
 
 serve: melted-check mosto.js server.js
-	@LOG_LEVEL=info ${NODE} server.js
+	@LOG_LEVEL=${LOG_LEVEL} ${NODE} server.js
 
 debug: melted-check mosto.js server.js
 	${NODE} --debug-brk server.js

--- a/test/general-functional-test.js
+++ b/test/general-functional-test.js
@@ -170,7 +170,11 @@ describe.skip("Mosto functional test", function() {
 
     self.publisher = mbc.pubsub();
     self.listener = mbc.pubsub();
-    self.db = mbc.db();
+    self.db = mbc.db({
+        dbName: 'mediatestdb',
+        dbHost: 'localhost',
+        dbPort: 27017
+    });
 
     /* generic tests */
     self.is_synced = function(done) {


### PR DESCRIPTION
This fixes an issue with the Makefile, now doing `make LOG_LEVEL=foo serve` works again, and the db is not dropped when the functional test is run
