### PR TITLE
Jmrunge/out of sync timeout

### DIFF
--- a/heartbeats.js
+++ b/heartbeats.js
@@ -224,7 +224,7 @@ heartbeats.prototype.syncMelted = function() {
                 logger.info("[syncMelted Expected and playing medias are the same");
                 if (Math.abs(meltedClip.currentFrame - expected.frame) > expected.media.get('fps')) {
                     logger.info("[syncMelted] I'm over 1 second off")
-                    result = result.then(self.fixMelted.bind(self, expected));
+                    result = result.then(self.fixMelted.bind(self, expected, expected.media.get('live')));
                 }
             }
             if (meltedStatus.status !== "playing") {
@@ -267,10 +267,12 @@ heartbeats.prototype.handleNoMedias = function() {
     logger.error("No medias loaded!");
 };
 
-heartbeats.prototype.fixMelted = function(expected) {
+heartbeats.prototype.fixMelted = function(expected, live) {
     var self = this;
-    logger.warn("Melted is out of sync!");
+    logger.warn("Melted is out of sync! (Live: %s)", live ? true : false);
     self.emit("outOfSync", expected);
+    if (live)
+        return;
     return self.server.goto(expected.media.get('actual_order'), expected.frame);
 };
 

--- a/models/Mosto.js
+++ b/models/Mosto.js
@@ -37,7 +37,8 @@ Mosto.Media = Backbone.Model.extend({
         // end: undefined,
         in: undefined,
         out: undefined,
-        blank: false
+        blank: false,
+        live: false
     },
 
     constructor: function(attributes, options) {


### PR DESCRIPTION
Added a timeout to outOfSync events: when 5 events occur in 5 seconds, playlists are reloaded (that cleans melted and make it work again)

Includes PR #147 
